### PR TITLE
Added textfit and some tweaks to make it work.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
 
         <script src="vendor/alpine.persist.3.13.7.min.js" defer></script>
         <script src="vendor/alpine.3.13.7.min.js" defer></script>
+        <script src="js/textfit.js"></script>
         <script src="js/app.js"></script>
 
         <script>

--- a/js/app.js
+++ b/js/app.js
@@ -339,6 +339,7 @@ function createToc() {
       window.permalink_to ?? 4
     );
     contents.innerHTML = createTOCListHtml(tocList, 'main-');
+    
   }
 }
 
@@ -348,5 +349,12 @@ document.addEventListener('DOMContentLoaded', () => {
   insertFileContents();
   createToc();
 });
+
+document.onreadystatechange = function () {
+  if (document.readyState == "complete") {
+    setTimeout( () => textFit(document.getElementsByTagName("h1")), "10");
+    setTimeout( () => textFit(document.getElementsByClassName("description")), "10");
+  }
+}
 
 console.log('App running successfully');

--- a/js/textfit.js
+++ b/js/textfit.js
@@ -1,0 +1,244 @@
+/**
+ * textFit v2.3.1
+ * Previously known as jQuery.textFit
+ * 11/2014 by STRML (strml.github.com)
+ * MIT License
+ *
+ * To use: textFit(document.getElementById('target-div'), options);
+ *
+ * Will make the *text* content inside a container scale to fit the container
+ * The container is required to have a set width and height
+ * Uses binary search to fit text with minimal layout calls.
+ * Version 2.0 does not use jQuery.
+ */
+/*global define:true, document:true, window:true, HTMLElement:true*/
+
+(function(root, factory) {
+  "use strict";
+
+  // UMD shim
+  if (typeof define === "function" && define.amd) {
+    // AMD
+    define([], factory);
+  } else if (typeof exports === "object") {
+    // Node/CommonJS
+    module.exports = factory();
+  } else {
+    // Browser
+    root.textFit = factory();
+  }
+
+}(typeof global === "object" ? global : this, function () {
+  "use strict";
+
+  var defaultTextFitSettings = {
+    alignVert: false, // if true, textFit will align vertically using css tables
+    alignHoriz: false, // if true, textFit will set text-align: center
+    multiLine: false, // if true, textFit will not set white-space: no-wrap
+    detectMultiLine: true, // disable to turn off automatic multi-line sensing
+    minFontSize: 6,
+    maxFontSize: 80,
+    reProcess: true, // if true, textFit will re-process already-fit nodes. Set to 'false' for better performance
+    widthOnly: false, // if true, textFit will fit text to element width, regardless of text height
+    alignVertWithFlexbox: false, // if true, textFit will use flexbox for vertical alignment
+  };
+
+  return function textFit(els, options) {
+
+    if (!options) options = {};
+
+    // Extend options.
+    var settings = {};
+    for(var key in defaultTextFitSettings){
+      if(options.hasOwnProperty(key)){
+        settings[key] = options[key];
+      } else {
+        settings[key] = defaultTextFitSettings[key];
+      }
+    }
+
+    // Convert jQuery objects into arrays
+    if (typeof els.toArray === "function") {
+      els = els.toArray();
+    }
+
+    // Support passing a single el
+    var elType = Object.prototype.toString.call(els);
+    if (elType !== '[object Array]' && elType !== '[object NodeList]' &&
+            elType !== '[object HTMLCollection]'){
+      els = [els];
+    }
+
+    // Process each el we've passed.
+    for(var i = 0; i < els.length; i++){
+      processItem(els[i], settings);
+    }
+  };
+
+  /**
+   * The meat. Given an el, make the text inside it fit its parent.
+   * @param  {DOMElement} el       Child el.
+   * @param  {Object} settings     Options for fit.
+   */
+  function processItem(el, settings){
+    if (!isElement(el) || (!settings.reProcess && el.getAttribute('textFitted'))) {
+      return false;
+    }
+
+    // Set textFitted attribute so we know this was processed.
+    if(!settings.reProcess){
+      el.setAttribute('textFitted', 1);
+    }
+
+    var innerSpan, originalHeight, originalHTML, originalWidth;
+    var low, mid, high;
+
+    // Get element data.
+    originalHTML = el.innerHTML;
+    originalWidth = innerWidth(el);
+    originalHeight = innerHeight(el);
+
+    // Don't process if we can't find box dimensions
+    if (!originalWidth || (!settings.widthOnly && !originalHeight)) {
+      if(!settings.widthOnly)
+        throw new Error('Set a static height and width on the target element ' + el.outerHTML +
+          ' before using textFit!');
+      else
+        throw new Error('Set a static width on the target element ' + el.outerHTML +
+          ' before using textFit!');
+    }
+
+    // Add textFitted span inside this container.
+    if (originalHTML.indexOf('textFitted') === -1) {
+      innerSpan = document.createElement('span');
+      innerSpan.className = 'textFitted';
+      // Inline block ensure it takes on the size of its contents, even if they are enclosed
+      // in other tags like <p>
+      innerSpan.style['display'] = 'inline-block';
+      innerSpan.innerHTML = originalHTML;
+      el.innerHTML = '';
+      el.appendChild(innerSpan);
+    } else {
+      // Reprocessing.
+      innerSpan = el.querySelector('span.textFitted');
+      // Remove vertical align if we're reprocessing.
+      if (hasClass(innerSpan, 'textFitAlignVert')){
+        innerSpan.className = innerSpan.className.replace('textFitAlignVert', '');
+        innerSpan.style['height'] = '';
+        el.className.replace('textFitAlignVertFlex', '');
+      }
+    }
+
+    // Prepare & set alignment
+    if (settings.alignHoriz) {
+      el.style['text-align'] = 'center';
+      innerSpan.style['text-align'] = 'center';
+    }
+
+    // Check if this string is multiple lines
+    // Not guaranteed to always work if you use wonky line-heights
+    var multiLine = settings.multiLine;
+    if (settings.detectMultiLine && !multiLine &&
+        innerSpan.getBoundingClientRect().height >= parseInt(window.getComputedStyle(innerSpan)['font-size'], 10) * 2){
+      multiLine = true;
+    }
+
+    // If we're not treating this as a multiline string, don't let it wrap.
+    if (!multiLine) {
+      el.style['white-space'] = 'nowrap';
+    }
+
+    low = settings.minFontSize;
+    high = settings.maxFontSize;
+
+    // Binary search for highest best fit
+    var size = low;
+    while (low <= high) {
+      mid = (high + low) >> 1;
+      innerSpan.style.fontSize = mid + 'px';
+      var innerSpanBoundingClientRect = innerSpan.getBoundingClientRect();
+      if (
+        innerSpanBoundingClientRect.width <= originalWidth 
+        && (settings.widthOnly || innerSpanBoundingClientRect.height <= originalHeight)
+      ) {
+        size = mid;
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+      // await injection point
+    }
+    // found, updating font if differs:
+    if( innerSpan.style.fontSize != size + 'px' ) innerSpan.style.fontSize = size + 'px';
+
+    // Our height is finalized. If we are aligning vertically, set that up.
+    if (settings.alignVert) {
+      addStyleSheet();
+      var height = innerSpan.scrollHeight;
+      if (window.getComputedStyle(el)['position'] === "static"){
+        el.style['position'] = 'relative';
+      }
+      if (!hasClass(innerSpan, "textFitAlignVert")){
+        innerSpan.className = innerSpan.className + " textFitAlignVert";
+      }
+      innerSpan.style['height'] = height + "px";
+      if (settings.alignVertWithFlexbox && !hasClass(el, "textFitAlignVertFlex")) {
+        el.className = el.className + " textFitAlignVertFlex";
+      }
+    }
+  }
+
+  // Calculate height without padding.
+  function innerHeight(el){
+    var style = window.getComputedStyle(el, null);
+    return el.getBoundingClientRect().height -
+      parseInt(style.getPropertyValue('padding-top'), 10) -
+      parseInt(style.getPropertyValue('padding-bottom'), 10);
+  }
+
+  // Calculate width without padding.
+  function innerWidth(el){
+    var style = window.getComputedStyle(el, null);
+    return el.getBoundingClientRect().width -
+      parseInt(style.getPropertyValue('padding-left'), 10) -
+      parseInt(style.getPropertyValue('padding-right'), 10);
+  }
+
+  //Returns true if it is a DOM element
+  function isElement(o){
+    return (
+      typeof HTMLElement === "object" ? o instanceof HTMLElement : //DOM2
+      o && typeof o === "object" && o !== null && o.nodeType === 1 && typeof o.nodeName==="string"
+    );
+  }
+
+  function hasClass(element, cls) {
+    return (' ' + element.className + ' ').indexOf(' ' + cls + ' ') > -1;
+  }
+
+  // Better than a stylesheet dependency
+  function addStyleSheet() {
+    if (document.getElementById("textFitStyleSheet")) return;
+    var style = [
+      ".textFitAlignVert{",
+        "position: absolute;",
+        "top: 0; right: 0; bottom: 0; left: 0;",
+        "margin: auto;",
+        "display: flex;",
+        "justify-content: center;",
+        "flex-direction: column;",
+      "}",
+      ".textFitAlignVertFlex{",
+        "display: flex;",
+      "}",
+      ".textFitAlignVertFlex .textFitAlignVert{",
+        "position: static;",
+      "}",].join("");
+
+    var css = document.createElement("style");
+    css.type = "text/css";
+    css.id = "textFitStyleSheet";
+    css.innerHTML = style;
+    document.body.appendChild(css);
+  }
+}));

--- a/projects/tasks/card.scss
+++ b/projects/tasks/card.scss
@@ -25,7 +25,7 @@ $types:
     --image-width: var(--available-width);
     --image-height: var(--available-width);
     --desc-overlap: 10mm;
-    --desc-height: calc((var(--available-height) - (var(--image-height) + var(--title-height) + var(--stat-height))) + var(--desc-overlap));
+    --desc-height: 70mm;
 
     font-family: "Ubuntu Mono", monospace;
     font-optical-sizing: auto;
@@ -83,7 +83,7 @@ $types:
             z-index: -1;
         }
         .description {
-            --top-margin: -10mm;
+            // --top-margin: -10mm;
             width: 100%;
             height: var(--desc-height);
             margin-top: var(--top-margin);

--- a/projects/tasks/cards.csv
+++ b/projects/tasks/cards.csv
@@ -1,5 +1,7 @@
 id,quantity,name,description,type,stat_atk,stat_healing,cost,image
 test,1,Really Really Long Description Here,,label,,,,
+test,1,Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Long Description Here,That was actually the title not the description so here‘s an even longer bunch of text to really try to get the point across that we could be talking vast numbers of words here really unknowable uncountable but definitely not infinite words that stretch on and on until who knows when and all of course as part of one phrase beacuse we‘re in a CSV here and so can‘t use commas without it being painful or maybe just very slightly awkward like maybe just a backslash would be fine or some quotation marks but we‘re so far through it now it seems wrong to start adding commas willy-nilly potentially ending the bit before true comedy has landed,label,,,,
+test,1,Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Long Description Here,here’s some text that is still pretty long but not quite as long as the ridiculous prior example,label,,,,
 12-gauge-pigtails,1,12 Gauge Pigtails,,label,,,,
 12-gauge-pigtails-ground,1,12 Gauge Pigtails (Ground),,label,,,,
 14-gauge-pigtails,1,14 Gauge Pigtails,,label,,,,


### PR DESCRIPTION
There are still many  
Unsolved things in CSS  
Like making text fit  

-----

Added [textFit](https://github.com/STRML/textFit) to make text in `h1` and `.description` resize dynamically depending on the amount of content in them.

Added app-wide:

*   [textFit](https://github.com/STRML/textFit)
*   Hacky invocation of `textFit` 10 seconds after page load, for `h1` elements and elements with the `.description` class

Added for `projects/tasks`:

*   Static height for `--desc-height`
*   CSV entries with long text

Removed from `projects/tasks`:

*   `--top-margin` for `.description`